### PR TITLE
Fix mime-type for ODS

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -370,7 +370,7 @@ var regExtStrMap = map[string]string{
 	"odt": "application/vnd.oasis.opendocument.text",
 	"odm": "application/vnd.oasis.opendocument.text-master",
 	"ott": "application/vnd.oasis.opendocument.text-template",
-	"ods": "application/vnd.oasis.opendocument.sheet",
+	"ods": "application/vnd.oasis.opendocument.spreadsheet",
 	"ots": "application/vnd.oasis.opendocument.spreadsheet-template",
 	"odg": "application/vnd.oasis.opendocument.graphics",
 	"otg": "application/vnd.oasis.opendocument.graphics-template",


### PR DESCRIPTION
According to https://www.openoffice.org/framework/documentation/mimetypes/mimetypes.html the mime-type for ODS should be application/vnd.oasis.opendocument.spreadsheet

Fixes #620
